### PR TITLE
Fixed error in comment regex when no space after #

### DIFF
--- a/policy/sysctl_conf_inventory.cf
+++ b/policy/sysctl_conf_inventory.cf
@@ -7,7 +7,7 @@ bundle agent sysctl_conf_inventory
       # Parse the file into a data structure
       "sysctl_conf_data"
         data => data_readstringarray($(sysctl_conf),
-                                     "\s*#[^\n]*",
+                                     "[ \t]*#[^\n]*",
                                      "\s?+=\s?+",
                                      inf,
                                      inf),


### PR DESCRIPTION
Fixing : "error: Comment regex '\s*#[^\n]*' was irreconcilable reading input '/etc/sysctl.conf' probably because it legally matches nothing "
When /etc/sysctl.conf contains only comments and one comment has no space after #. like this:
```
----------- /etc/sysctl.conf -----------
# System default settings live in /usr/lib/sysctl.d/00-system.conf.
# To override those settings, enter new settings here, or in an /etc/sysctl.d/<name>.conf file
#
# For more information, see sysctl.conf(5) and sysctl.d(5).
---------------------------------------
```
The error also occurs in this example:
```
---------------------------------------
# Controls IP packet forwarding
#net.ipv4.ip_forward = 0
---------------------------------------
```
Problems is that \s also captures \n and this for some reason confuses CFEngine/pcre. Replaced with [ (space)\t]