### PR TITLE
Use 'index' instead of 'modules' in cfbs.json

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -1,5 +1,5 @@
 {
-  "modules": {
+  "index": {
     "inventory-kernel-settings-sysctl-current": {
       "description": "Inventory sysctl settings current state.",
       "tags": ["inventory", "sysctl"],


### PR DESCRIPTION
Changed in https://github.com/cfengine/cfbs/commit/ce32113268ec5ca616d311cf90a4dbbf2096af28